### PR TITLE
[Sage-1220] Split node and beehive publish intervals.

### DIFF
--- a/main.py
+++ b/main.py
@@ -84,7 +84,7 @@ def start_publishing(args, plugin):
                 logging.info("failed to parse %s %s data %r as numeric", sensor_name, name, text)
                 continue
 
-            plugin.publish(f"iio.{name}", value, meta={"sensor": sensor_name}, scope="node")
+            plugin.publish(f"iio.{name}", value, meta={"sensor": sensor_name}, scope=scope)
             logging.debug("published %s %s %s", sensor_name, name, value)
             total_iio_published += 1
 
@@ -95,7 +95,7 @@ def start_publishing(args, plugin):
                 logging.debug("no transform for %s %s - skipping", sensor_name, name)
                 continue
 
-            plugin.publish(f"env.{tfm_name}", tfm_value, meta={"sensor": sensor_name}, scope="node")
+            plugin.publish(f"env.{tfm_name}", tfm_value, meta={"sensor": sensor_name}, scope=scope)
             logging.debug("published transformed value %s %s %s", sensor_name, tfm_name, tfm_value)
             total_env_published += 1
 

--- a/test_main.sh
+++ b/test_main.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-# python3 main.py --root test/sys/bus/iio/devices/ --debug --rate 1
-python3 main.py --root test/sys/bus/iio/devices/ --rate 1
+# python3 main.py --root test/sys/bus/iio/devices/ --debug
+python3 main.py --root test/sys/bus/iio/devices/


### PR DESCRIPTION
This PR allow the IIO plugin to publish data to the node and beehive at different intervals.

These intervals are specified with the new --node-publish-interval and --beehive-publish-interval flags, which replace the --rate flag.

Note: These two sampling schedules are logically independent of each other. No attempt is made to share a common sample if the timing happens to coincide.
